### PR TITLE
class_loader dependency is added to nodelet_tutorial_math package

### DIFF
--- a/nodelet_tutorial_math/CMakeLists.txt
+++ b/nodelet_tutorial_math/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(nodelet_tutorial_math)
 
-find_package(catkin REQUIRED COMPONENTS nodelet roscpp std_msgs)
+find_package(catkin REQUIRED COMPONENTS nodelet roscpp std_msgs class_loader)
 
 ## Setup include directories
 include_directories(${catkin_INCLUDE_DIRS})

--- a/nodelet_tutorial_math/package.xml
+++ b/nodelet_tutorial_math/package.xml
@@ -13,6 +13,7 @@
   <build_depend>nodelet</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>class_loader</build_depend>
 
   <run_depend>nodelet</run_depend>
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
Fixes the undefined symbol errors when linking libnodelet_math library on Mac OS X
