### PR TITLE
changed shape_server code to run with the hydro

### DIFF
--- a/turtle_actionlib/CMakeLists.txt
+++ b/turtle_actionlib/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED
     roscpp
     std_msgs
     turtlesim
+    geometry_msgs
 )
 
 ## Add message definitions

--- a/turtle_actionlib/package.xml
+++ b/turtle_actionlib/package.xml
@@ -22,6 +22,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>turtlesim</build_depend>
+  <build_depend>geometry_msgs</build_depend>
 
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
@@ -31,6 +32,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>turtlesim</run_depend>
+  <run_depend>geometry_msgs</run_depend>
 
 </package>
 

--- a/turtle_actionlib/src/shape_server.cpp
+++ b/turtle_actionlib/src/shape_server.cpp
@@ -5,7 +5,7 @@
 #include <math.h>
 #include <angles/angles.h>
 
-#include <turtle_actionlib/Velocity.h>
+#include <geometry_msgs/Twist.h>
 #include <turtle_actionlib/ShapeAction.h>
 
 // This class computes the command_velocities of the turtle to draw regular polygons 
@@ -22,7 +22,7 @@ public:
 
     //subscribe to the data topic of interest
     sub_ = nh_.subscribe("/turtle1/pose", 1, &ShapeAction::controlCB, this);
-    pub_ = nh_.advertise<turtle_actionlib::Velocity>("/turtle1/command_velocity", 1);
+    pub_ = nh_.advertise<geometry_msgs::Twist>("/turtle1/cmd_vel", 1);
 
     as_.start();
   }
@@ -85,25 +85,25 @@ public:
      
       if (dis_error_ > error_tol)
       {
-        command_.linear = l_scale*dis_error_;
-        command_.angular = 0;
+        command_.linear.x = l_scale*dis_error_;
+        command_.angular.z = 0;
       }
       else if (dis_error_ < error_tol && fabs(theta_error_)> error_tol)
       { 
-        command_.linear = 0;
-        command_.angular = a_scale*theta_error_;
+        command_.linear.x = 0;
+        command_.angular.z = a_scale*theta_error_;
       }
       else if (dis_error_ < error_tol && fabs(theta_error_)< error_tol)
       {
-        command_.linear = 0;
-        command_.angular = 0;
+        command_.linear.x = 0;
+        command_.angular.z = 0;
         start_edge_ = true;
         edge_progress_++;
       }  
       else
       {
-        command_.linear = l_scale*dis_error_;
-        command_.angular = a_scale*theta_error_;
+        command_.linear.x = l_scale*dis_error_;
+        command_.angular.z = a_scale*theta_error_;
       } 
       // publish the velocity command
       pub_.publish(command_);
@@ -126,7 +126,7 @@ protected:
   double dis_error_, theta_error_;
   int edges_ , edge_progress_;
   bool start_edge_;
-  turtle_actionlib::Velocity command_;
+  geometry_msgs::Twist command_;
   turtle_actionlib::ShapeResult result_;
   ros::Subscriber sub_;
   ros::Publisher pub_;


### PR DESCRIPTION
Hi,

I just recognized that the hydro version of the shape_server does not work.
In Hydro turtlesim changed the navigation message type from "turtle_actionlib/Velocity.h" to "geometry_msgs/Twist.h" and the corresponding topic from "command_velocity" to "cmd_vel"

This fix will solve the problem

I have no idea why noone had this problem before
