### PR TITLE
Use _EXPORTED_TARGETS target suffix instead of _generate_messages_cpp

### DIFF
--- a/actionlib_tutorials/CMakeLists.txt
+++ b/actionlib_tutorials/CMakeLists.txt
@@ -25,17 +25,17 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 ## Averaging server
 add_executable(averaging_server src/averaging_server.cpp)
 target_link_libraries(averaging_server ${catkin_LIBRARIES})
-add_dependencies(averaging_server ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(averaging_server ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Averaging client
 add_executable(averaging_client src/averaging_client.cpp)
 target_link_libraries(averaging_client ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-add_dependencies(averaging_client ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(averaging_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Fibonacci server
 add_executable(fibonacci_server src/fibonacci_server.cpp)
 target_link_libraries(fibonacci_server ${catkin_LIBRARIES})
-add_dependencies(fibonacci_server ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(fibonacci_server ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Fibonacci client
 add_executable(fibonacci_client src/fibonacci_client.cpp)
@@ -43,7 +43,7 @@ target_link_libraries(fibonacci_client ${catkin_LIBRARIES})
 if(catkin_EXPORTED_TARGETS)
   add_dependencies(fibonacci_client ${catkin_EXPORTED_TARGETS})
 endif()
-add_dependencies(fibonacci_client ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(fibonacci_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Install scripts and executables
 install(PROGRAMS scripts/gen_numbers.py

--- a/turtle_actionlib/CMakeLists.txt
+++ b/turtle_actionlib/CMakeLists.txt
@@ -33,12 +33,12 @@ include_directories(${catkin_INCLUDE_DIRS})
 ## shape_server executable
 add_executable(shape_server src/shape_server.cpp)
 target_link_libraries(shape_server ${catkin_LIBRARIES})
-add_dependencies(shape_server ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(shape_server ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## shape_client executable
 add_executable(shape_client src/shape_client.cpp)
 target_link_libraries(shape_client ${catkin_LIBRARIES})
-add_dependencies(shape_client ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(shape_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Mark executables for installation
 install(TARGETS shape_server shape_client


### PR DESCRIPTION
_EXPORTED_TARGETS target suffix is preferred over _generate_messages_cpp, see https://github.com/ros/catkin_tutorials/issues/6
