### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/nodelet_tutorial_math/src/plus.cpp
+++ b/nodelet_tutorial_math/src/plus.cpp
@@ -68,5 +68,5 @@ private:
   double value_;
 };
 
-PLUGINLIB_DECLARE_CLASS(nodelet_tutorial_math, Plus, nodelet_tutorial_math::Plus, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(nodelet_tutorial_math::Plus, nodelet::Nodelet)
 }


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions