### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/actionlib_tutorials/CMakeLists.txt
+++ b/actionlib_tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(actionlib_tutorials)
 
 ## Find catkin dependencies

--- a/common_tutorials/CMakeLists.txt
+++ b/common_tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(common_tutorials)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/nodelet_tutorial_math/CMakeLists.txt
+++ b/nodelet_tutorial_math/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(nodelet_tutorial_math)
 
 find_package(catkin REQUIRED COMPONENTS nodelet roscpp std_msgs)

--- a/pluginlib_tutorials/CMakeLists.txt
+++ b/pluginlib_tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pluginlib_tutorials)
 
 ## Find catkin dependencies

--- a/turtle_actionlib/CMakeLists.txt
+++ b/turtle_actionlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(turtle_actionlib)
 
 ## Find catkin dependencies


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Maybe this should be targeted at a `kinetic-devel` or `noetic-devel` branch since 3.0.2 is greater than the minimum version supported by ROS Indigo?

ros/catkin#1052