### PR TITLE
fix shebang line for python3

### DIFF
--- a/actionlib_tutorials/scripts/fibonacci_client.py
+++ b/actionlib_tutorials/scripts/fibonacci_client.py
@@ -1,6 +1,8 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 from __future__ import print_function
+
+import sys
 
 import rospy
 # Brings in the SimpleActionClient

--- a/actionlib_tutorials/scripts/fibonacci_server.py
+++ b/actionlib_tutorials/scripts/fibonacci_server.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import rospy
 

--- a/actionlib_tutorials/scripts/gen_numbers.py
+++ b/actionlib_tutorials/scripts/gen_numbers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import rospy


### PR DESCRIPTION
These scripts can currently not be ran in Noetic/Focal and result in:
/usr/bin/env: ‘python’: No such file or directory

This updates the shebang line to point to Python 3 that is the python version targeted by ROS Noetic