### PR TITLE
use boost::placeholders::_1/_2 instead of deprecated _1/_2

### DIFF
--- a/actionlib_tutorials/src/fibonacci_class_client.cpp
+++ b/actionlib_tutorials/src/fibonacci_class_client.cpp
@@ -22,7 +22,7 @@ public:
 
     // Need boost::bind to pass in the 'this' pointer
     ac.sendGoal(goal,
-                boost::bind(&MyNode::doneCb, this, _1, _2),
+                boost::bind(&MyNode::doneCb, this, boost::placeholders::_1, boost::placeholders::_2),
                 Client::SimpleActiveCallback(),
                 Client::SimpleFeedbackCallback());
 

--- a/actionlib_tutorials/src/fibonacci_server.cpp
+++ b/actionlib_tutorials/src/fibonacci_server.cpp
@@ -16,7 +16,7 @@ protected:
 public:
 
   FibonacciAction(std::string name) :
-    as_(nh_, name, boost::bind(&FibonacciAction::executeCB, this, _1), false),
+    as_(nh_, name, boost::bind(&FibonacciAction::executeCB, this, boost::placeholders::_1), false),
     action_name_(name)
   {
     as_.start();

--- a/nodelet_tutorial_math/src/plus.cpp
+++ b/nodelet_tutorial_math/src/plus.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 #include <ros/ros.h>
 #include <std_msgs/Float64.h>

--- a/pluginlib_tutorials/src/polygon_loader.cpp
+++ b/pluginlib_tutorials/src/polygon_loader.cpp
@@ -38,7 +38,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <pluginlib_tutorials/polygon_base.h>
 
 int main(int argc, char** argv)

--- a/pluginlib_tutorials/src/polygon_loader.cpp
+++ b/pluginlib_tutorials/src/polygon_loader.cpp
@@ -40,6 +40,7 @@
 
 #include <pluginlib/class_loader.hpp>
 #include <pluginlib_tutorials/polygon_base.h>
+#include <ros/ros.h>
 
 int main(int argc, char** argv)
 {

--- a/pluginlib_tutorials/src/polygon_plugins.cpp
+++ b/pluginlib_tutorials/src/polygon_plugins.cpp
@@ -35,7 +35,7 @@
 * Author: Eitan Marder-Eppstein
 * Author: Isaac Saito
 *********************************************************************/
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pluginlib_tutorials/polygon_base.h>
 #include <pluginlib_tutorials/polygon_plugins.h>
 


### PR DESCRIPTION
Eliminates build warnings